### PR TITLE
Fixed ProductSearchString for product selection not working

### DIFF
--- a/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
+++ b/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
@@ -198,8 +198,7 @@ export class ProductSelectionComponent implements OnInit, OnDestroy {
       // TODO load all according to this.categoryModel.SelectedCategory
     }
 
-    this.searchString = this.activatedRoute.snapshot.paramMap.get('ProductSearchString');
-
+    this.searchString = this.activatedRoute.snapshot.queryParams["ProductSearchString"];
     if (this.searchString) {
       /* user can pass product search string by URL parameter -> load the data with this search string
        */

--- a/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
+++ b/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
@@ -199,6 +199,7 @@ export class ProductSelectionComponent implements OnInit, OnDestroy {
     }
 
     this.searchString = this.activatedRoute.snapshot.queryParams["ProductSearchString"];
+
     if (this.searchString) {
       /* user can pass product search string by URL parameter -> load the data with this search string
        */

--- a/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
+++ b/imxweb/projects/qer/src/lib/product-selection/product-selection.component.ts
@@ -198,7 +198,7 @@ export class ProductSelectionComponent implements OnInit, OnDestroy {
       // TODO load all according to this.categoryModel.SelectedCategory
     }
 
-    this.searchString = this.activatedRoute.snapshot.queryParams["ProductSearchString"];
+    this.searchString = this.activatedRoute.snapshot.queryParams['ProductSearchString'];
 
     if (this.searchString) {
       /* user can pass product search string by URL parameter -> load the data with this search string


### PR DESCRIPTION
Hey there,
this little pr should fix the `ProductSearchString` varaible, which allows to deep link search result for the product selection.

**How to test?**
Open link in your angular portal: https:// yourAPIServer /productselection?ProductSearchString=ProductName

Current behavior: the search bar will be empty.
With this pr merged: the search bar will be set to `ProductName`.

In Regards
Matthias