### PR TITLE
Update cdr.module.ts

### DIFF
--- a/imxweb/projects/qbm/src/lib/cdr/cdr.module.ts
+++ b/imxweb/projects/qbm/src/lib/cdr/cdr.module.ts
@@ -129,9 +129,7 @@ import { EditUrlComponent } from './edit-url/edit-url.component';
     DateModule,
     ImageModule
   ],
-  providers: [
-    CdrRegistryService
-  ],
+  providers: [  ],
   exports: [
     CdrEditorComponent,
     EditDefaultComponent,


### PR DESCRIPTION
To my opinion the CdrRegistryService should be a singleton, which should only instanced by "root".  If you provide another instance of the CdrRegistryService, then the CdrRegistryService is not a singleton anymore,  it is hard to register a new custom cdrEditor. Hence I always remove this line in my project