### PR TITLE
Force mat-drawer to relative, otherwise service categories are not visible anymore.

### DIFF
--- a/imxweb/projects/qbm/src/lib/sidenav-tree/sidenav-tree.component.scss
+++ b/imxweb/projects/qbm/src/lib/sidenav-tree/sidenav-tree.component.scss
@@ -4,6 +4,10 @@
   height: 100%;
   border-radius: 4px;
 
+  ::ng-deep .mat-drawer {
+    position: relative !important;
+  }
+  
   ::ng-deep .mat-drawer-inner-container {
     overflow: hidden;
   }


### PR DESCRIPTION
In material ui .mat-drawer has 2 settings for position, first is "relative", followed by "absolute" which is overruling the relative. so mat-drawer has position: absolute, which leads to display issues (service categories not visible)

<img width="772" alt="visual issue" src="https://github.com/OneIdentity/IdentityManager.Imx/assets/1102080/7a151b98-1f1e-4641-b0d9-5678b8c12783">

![MicrosoftTeams-image (1)](https://github.com/OneIdentity/IdentityManager.Imx/assets/1102080/fb7b0417-ce9b-4748-8918-a87d160037fd)
