### PR TITLE
[v92] Readded ProductSearchString for new itshop

### DIFF
--- a/imxweb/projects/qer/src/lib/new-request/new-request-header/new-request-header-toolbar/new-request-header-toolbar.component.html
+++ b/imxweb/projects/qer/src/lib/new-request/new-request-header/new-request-header-toolbar/new-request-header-toolbar.component.html
@@ -15,6 +15,7 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>
 <imx-data-source-toolbar
@@ -29,6 +30,7 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>
 <imx-data-source-toolbar
@@ -43,6 +45,7 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>
 <imx-data-source-toolbar
@@ -57,6 +60,7 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>
 <imx-data-source-toolbar
@@ -71,6 +75,7 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>
 <imx-data-source-toolbar
@@ -85,5 +90,6 @@
   [disableSearch]="disableSearch"
   [options]="['search']"
   [searchApi]="searchApi"
+  (settingsChanged)="onSettingChanged($event)"
   (navigationStateChanged)="onNavigationChanged($event)"
 ></imx-data-source-toolbar>

--- a/imxweb/projects/qer/src/lib/new-request/new-request-header/new-request-header-toolbar/new-request-header-toolbar.component.ts
+++ b/imxweb/projects/qer/src/lib/new-request/new-request-header/new-request-header-toolbar/new-request-header-toolbar.component.ts
@@ -25,6 +25,7 @@
  */
 
 import { Component, OnDestroy, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Subscription } from 'rxjs/internal/Subscription';
 
@@ -56,14 +57,18 @@ export class NewRequestHeaderToolbarComponent implements OnDestroy {
   public selectedCategory: PortalServicecategories;
   public showCatInfo = false;
   public searchBoxText = '#LDS#Search';
+  public initialSearch: string;
   public SelectedProductSource = SelectedProductSource;
   public selectedView: SelectedProductSource;
   public disableSearch = false;
 
+  private initialSearched = false;
+
   @ViewChild(DataSourceToolbarComponent) public dst: DataSourceToolbarComponent;
   //#endregion
 
-  constructor(public readonly orchestration: NewRequestOrchestrationService) {
+  constructor(public readonly orchestration: NewRequestOrchestrationService,
+    private activatedRoute: ActivatedRoute,) {
     this.subscriptions.push(
       this.orchestration.searchApi$.subscribe(searchApi => {
         this.searchApi = searchApi;
@@ -102,10 +107,21 @@ export class NewRequestHeaderToolbarComponent implements OnDestroy {
     }));
   }
 
+  public async ngOnInit(): Promise<void> {
+    this.initialSearch = this.activatedRoute.snapshot.queryParams['ProductSearchString'];
+  }
+
   public ngOnDestroy(): void {
     this.subscriptions.forEach((subscription: Subscription) => subscription.unsubscribe());
   }
 
+  public onSettingChanged(setting?: DataSourceToolbarSettings): void {
+    if(setting && this.initialSearch && !this.initialSearched) {
+      this.dst.keywords = this.initialSearch;
+      this.dst.searchControl.setValue(this.initialSearch);
+      this.initialSearched = true;
+    }
+  }
 
   public onNavigationChanged(newState?: CollectionLoadParameters | ServiceItemParameters): void {
     this.orchestration.navigationState = newState;


### PR DESCRIPTION
Hey there,
this pull request readds `ProductSearchString`. Originally I created a pr for a fix for 9.1: https://github.com/OneIdentity/IdentityManager.Imx/pull/79. Unfortunately this never got fixed, so i figured it would be a good idea to attempt this for 9.2 again.

**How to test?**
Open link in your angular portal: `https:// yourAPIServer /#/newrequest/allProducts?ProductSearchString=ProductName`
