### PR TITLE
Fix: Clear the selection first when the preselection is changed.

### DIFF
--- a/imxweb/projects/qbm/src/lib/data-source-toolbar/data-source-toolbar.component.ts
+++ b/imxweb/projects/qbm/src/lib/data-source-toolbar/data-source-toolbar.component.ts
@@ -904,6 +904,7 @@ export class DataSourceToolbarComponent implements OnChanges, OnInit, OnDestroy 
       this.isUpdatingPreselection = true;
 
       setTimeout(() => {
+        this.selection.clear();
         this.preSelection.forEach((item) => this.selection.checked(item));
         this.isUpdatingPreselection = false;
       });


### PR DESCRIPTION
"If I reset the preselection, I would expect only the newly selected objects to be highlighted, rather than both the old and new preselection being selected."