### PR TITLE
Method confirmGeneral does not return false on OkResult -> fixed

### DIFF
--- a/imxweb/projects/qbm/src/lib/confirmation/confirmation.service.ts
+++ b/imxweb/projects/qbm/src/lib/confirmation/confirmation.service.ts
@@ -93,7 +93,8 @@ export class ConfirmationService {
       },
       panelClass: 'imx-messageDialog',
     });
-    return (await dialogRef.afterClosed().toPromise()) === MessageDialogResult.YesResult;
+    const result = await dialogRef.afterClosed().toPromise();
+    return result === MessageDialogResult.YesResult || result === MessageDialogResult.OkResult;
   }
 
   // Damit es bis "Pull Request 38432: 299557-imxweb-confirmdialogs-with-yes-no-buttons" funktioniert


### PR DESCRIPTION
The implementation of confirmGeneral(data: MessageParameter) returns true in case that the result of the dialogRef is equal to the YesResult. But within the MessageParameter you can decide to work with the OK & Cancel-Buttons. So I would expect that the OkResult is also a positive result of the dialogReg, and the return value should be true.