### PR TITLE
Remove npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.npmrc
+*.env

--- a/imxweb/.gitignore
+++ b/imxweb/.gitignore
@@ -56,3 +56,4 @@ debug.log
 .angular
 .nx
 *.env
+.npmrc

--- a/imxweb/.npmrc
+++ b/imxweb/.npmrc
@@ -1,3 +1,0 @@
-@imx-modules:registry=https://pkgs.dev.azure.com/1id/_packaging/OneIdentity/npm/registry/
-@elemental-ui:registry=https://pkgs.dev.azure.com/1id/_packaging/OneIdentity/npm/registry/
-# always-auth=true


### PR DESCRIPTION
Adds .npmrc to the gitignore at both the imxweb and root level
Removes npmrc so that no unnecessary paging to a registry happens

Fixes #374