### PR TITLE
Add path parameters to DynamicMethod.do_get

### DIFF
--- a/imxweb/projects/qbm/src/lib/api-client/dynamic-method.ts
+++ b/imxweb/projects/qbm/src/lib/api-client/dynamic-method.ts
@@ -74,8 +74,11 @@ export class DynamicMethod {
     return this.builder.buildReadWriteEntity({ entitySchema: this.getSchema(), entityData: initialData });
   }
 
-  async Get(parametersOptional: any = {}) {
-    const data = await this.apiClient.processRequest(this.do_get(parametersOptional));
+  async Get(parameters: {
+    path?: any,
+    query?: any,
+  } = {}) {
+    const data = await this.apiClient.processRequest(this.do_get(parameters.path, parameters.query));
     return this.builder.buildReadWriteEntities(data, this.getSchema());
   }
 
@@ -93,13 +96,21 @@ export class DynamicMethod {
     return this.builder.buildReadWriteEntities(data, this.getSchema());
   }
 
-  private do_get(parametersOptional: any): MethodDescriptor<EntityCollectionData> {
-
+  private do_get(pathParameters?: any, queryParameters?: any): MethodDescriptor<EntityCollectionData> {
     const parameters = [];
-    for (var p in parametersOptional) {
+
+    for (const p in pathParameters) {
       parameters.push({
         name: p,
-        value: parametersOptional[p],
+        value: pathParameters[p],
+        in: 'path',
+      });
+    }
+
+    for (const p in queryParameters) {
+      parameters.push({
+        name: p,
+        value: queryParameters[p],
         in: 'query'
       });
     }

--- a/imxweb/projects/qer/src/lib/role-management/role-memberships/membership-handlers.ts
+++ b/imxweb/projects/qer/src/lib/role-management/role-memberships/membership-handlers.ts
@@ -103,18 +103,18 @@ export abstract class BaseMembership implements IRoleMembershipType {
 
   public async get(id: string, navigationState?: CollectionLoadParameters): Promise<ExtendedTypedEntityCollection<TypedEntity, unknown>> {
     const api = new DynamicMethod(this.dynamicRoleUrl, `/${this.basePath}/${id}`, this._api.apiClient, this._session, this._translator);
-    return api.Get(navigationState);
+    return api.Get({query: navigationState});
   }
 
   public async getCandidates(
     id: string,
     navigationState?: CandidateParameters,
   ): Promise<ExtendedTypedEntityCollection<TypedEntity, unknown>> {
-    
+
     const schemaPath =( this.fkCandidateRoute?.Url?.[0] === '/' ? this.fkCandidateRoute.Url.substring(1) : this.fkCandidateRoute.Url);
     const api = new DynamicMethod(schemaPath, (this.fkCandidateRoute?.Url), this._api.apiClient, this._session, this._translator);
     if (this.fkCandidateRoute?.HttpMethod === 'GET') {
-      return api.Get(navigationState);
+      return api.Get({path: {[this.columnName]: id},query: navigationState});
     }
 
     const state = {};


### PR DESCRIPTION
Fixes small bug where the UID part of a GET request through a DynamicMethod was not passed through:

Before: 
<img width="321" height="64" alt="firefox_i6a0zdIG2i" src="https://github.com/user-attachments/assets/85521282-80f5-49e9-82fd-ae14668611b9" />

After:
<img width="311" height="54" alt="image" src="https://github.com/user-attachments/assets/3536c321-35a7-449a-aafc-c64d38e318b1" />

