### PR TITLE
Fixed bitmask edit not having correct margins

### DIFF
--- a/imxweb/projects/qbm/src/lib/cdr/edit-bitmask/edit-bitmask.component.scss
+++ b/imxweb/projects/qbm/src/lib/cdr/edit-bitmask/edit-bitmask.component.scss
@@ -1,3 +1,4 @@
 :host {
   flex-grow: 1;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
Hey there,

seems like the bitmask cdr component does not have correct margins.

<img width="1433" height="288" alt="grafik" src="https://github.com/user-attachments/assets/80e50f9a-2f0a-436a-8ccf-4f9279d137ad" />

This pull requests adds it (i copied this over from other components). This achieves the accepted result:
<img width="1430" height="311" alt="grafik" src="https://github.com/user-attachments/assets/12c1ebc0-2db6-4332-b5d2-1634f0955125" />
