### PR TITLE
Fixed edit-multi-value not accepting changes from script

### DIFF
--- a/imxweb/projects/qbm/src/lib/cdr/edit-multi-value/edit-multi-value.component.ts
+++ b/imxweb/projects/qbm/src/lib/cdr/edit-multi-value/edit-multi-value.component.ts
@@ -106,7 +106,7 @@ export class EditMultiValueComponent implements CdrEditor, OnDestroy {
 
       this.subscribers.push(
         this.columnContainer.subscribe(() => {
-          if (!this.isWriting) {
+          if (this.isWriting) {
             return;
           }
           if (this.control.value !== this.columnContainer.value) {


### PR DESCRIPTION
I have enabled multivalue in one of my request property and from this point on I could not set a value from the script.

I checked if the correct information is sent to the front end. It is and therefore I searched why it is not set.

It is a very small issue. I guess just a small typo. This if should probably stop an update loop, but it is inverted will it should not.